### PR TITLE
Add optional diff and suggestions

### DIFF
--- a/index.html
+++ b/index.html
@@ -156,9 +156,14 @@
             <div id="result-section" class="mt-12 hidden">
                 <div class="flex justify-between items-center mb-3 border-b-2 border-gray-300 dark:border-gray-700 pb-2">
                     <h2 id="result-title" class="text-2xl font-semibold"></h2>
-                    <button id="copy-button" class="bg-gray-200 hover:bg-gray-300 dark:bg-gray-700 dark:hover:bg-gray-600 text-sm font-medium py-2 px-4 rounded-lg">
-                        Copiar
-                    </button>
+                    <div class="flex gap-2">
+                        <button id="copy-button" class="bg-gray-200 hover:bg-gray-300 dark:bg-gray-700 dark:hover:bg-gray-600 text-sm font-medium py-2 px-4 rounded-lg">
+                            Copiar
+                        </button>
+                        <button id="toggle-changes-btn" class="bg-gray-200 hover:bg-gray-300 dark:bg-gray-700 dark:hover:bg-gray-600 text-sm font-medium py-2 px-4 rounded-lg hidden">
+                            Mostrar cambios
+                        </button>
+                    </div>
                 </div>
                 <div class="bg-white dark:bg-gray-800 p-4 rounded-lg shadow">
                     <pre id="result-text-container" class="whitespace-pre-wrap font-sans"></pre>
@@ -166,6 +171,12 @@
                 <div id="response-info" class="mt-2 text-sm flex items-center gap-2 hidden">
                     <span id="response-time" class="font-medium"></span>
                     <span id="response-indicator" class="w-3 h-3 rounded-full"></span>
+                </div>
+                <div id="changes-section" class="hidden mt-4 bg-white dark:bg-gray-800 p-4 rounded-lg shadow">
+                    <h3 id="changes-title" class="text-lg font-semibold mb-2">Cambios realizados</h3>
+                    <ul id="changes-list" class="list-disc list-inside text-sm space-y-1"></ul>
+                    <h3 id="suggestions-title" class="text-lg font-semibold mt-4 mb-2">Sugerencias</h3>
+                    <ul id="suggestions-list" class="list-disc list-inside text-sm space-y-1"></ul>
                 </div>
             </div>
         </main>


### PR DESCRIPTION
## Summary
- show an optional "Mostrar cambios" button for each result
- parse AI responses as JSON to display changes and suggestions
- translate the new UI strings to English and Spanish
- update prompts to produce JSON with result, changes and suggestions
- render diff lists on demand

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684a8391586883268a3fbe4d33cef55a