### PR TITLE
Implement hamburger menu and simplify user auth display

### DIFF
--- a/index.html
+++ b/index.html
@@ -93,9 +93,12 @@
         <div id="user-auth-area" class="fixed top-4 right-20 z-20 flex items-center gap-3">
             </div>
         
-        <div id="nav-menu" class="fixed top-4 right-4 z-20 flex items-center gap-2">
-            <button id="history-toggle" class="bg-gray-700 hover:bg-gray-600 text-white font-bold py-2 px-4 rounded-full shadow-lg transition-transform transform hover:scale-110">🕒 Historial</button>
-            <a href="herramientas/articulos.html" id="create-articles" class="bg-green-600 hover:bg-green-700 text-white font-bold py-2 px-4 rounded-full shadow-lg transition-transform transform hover:scale-110">Crear Artículos</a>
+        <div id="nav-menu" class="fixed top-4 right-4 z-20 relative">
+            <button id="menu-toggle" class="text-2xl bg-gray-700 hover:bg-gray-600 text-white p-2 rounded-lg">☰</button>
+            <div id="menu-items" class="hidden absolute right-0 mt-2 w-48 bg-white dark:bg-gray-800 rounded-lg shadow-lg p-2 flex flex-col gap-2">
+                <button id="history-toggle" class="bg-gray-700 hover:bg-gray-600 text-white font-bold py-2 px-4 rounded-lg">🕒 Historial</button>
+                <a href="herramientas/articulos.html" id="create-articles" class="bg-green-600 hover:bg-green-700 text-white font-bold py-2 px-4 rounded-lg">Crear Artículos</a>
+            </div>
         </div>
         
         <div id="settings-modal" class="hidden fixed inset-0 bg-black bg-opacity-50 backdrop-blur-sm z-30 flex items-center justify-center">

--- a/js/main.js
+++ b/js/main.js
@@ -260,6 +260,8 @@ document.addEventListener('DOMContentLoaded', () => {
     const suggestionsTitleEl = document.getElementById('suggestions-title');
 
     const navMenu = document.getElementById("nav-menu");
+    const menuToggleBtn = document.getElementById('menu-toggle');
+    const menuItems = document.getElementById('menu-items');
     // --- AUTH, MODALS & SETTINGS LOGIC ---
     const showLoginModal = () => loginRequiredModal.classList.remove('hidden');
     const hideLoginModal = () => loginRequiredModal.classList.add('hidden');
@@ -267,7 +269,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const updateAuthStateUI = async () => {
         if (puter.auth.isSignedIn()) {
             const user = await puter.auth.getUser();
-            userAuthArea.innerHTML = `<span class="text-sm font-medium text-gray-800 dark:text-gray-200">${getT('hello')} ${user.username}</span>`;
+            userAuthArea.innerHTML = `<span class="text-sm font-medium text-gray-800 dark:text-gray-200">${user.username}</span>`;
             logoutBtnSettings.classList.remove('hidden');
         } else {
             userAuthArea.innerHTML = `<button id="sign-in-btn" class="bg-green-600 text-white text-sm font-bold py-2 px-4 rounded-lg hover:bg-green-700">${getT('signIn')}</button>`;
@@ -590,6 +592,10 @@ document.addEventListener('DOMContentLoaded', () => {
             const mailto = `mailto:service.correctia@gmail.com?subject=Correctia%20Feedback&body=${encodeURIComponent(comment)}`;
             window.location.href = mailto;
             feedbackModal.classList.add('hidden');
+        });
+
+        menuToggleBtn.addEventListener('click', () => {
+            menuItems.classList.toggle('hidden');
         });
 
         renderHistory();


### PR DESCRIPTION
## Summary
- add hamburger navigation menu with history and article links
- remove greeting prefix from the user authentication area

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684b952c42f88326807b2c8aaf4c6803