### PR TITLE
Fix navigation menu position and blur overlay

### DIFF
--- a/index.html
+++ b/index.html
@@ -26,7 +26,6 @@
 </head>
 <body class="bg-gray-100 dark:bg-gray-900 text-gray-800 dark:text-gray-200 font-sans flex flex-col min-h-screen">
 
-    <div class="container mx-auto max-w-4xl p-4 md:p-8 flex-grow">
         
         <button id="settings-toggle" class="fixed top-4 left-4 z-20 bg-gray-700 hover:bg-gray-600 text-white font-bold p-3 rounded-full shadow-lg transition-transform transform hover:scale-110">
             <img src="https://www.svgrepo.com/show/193270/settings-gear.svg" alt="Ajustes" class="h-5 w-5">
@@ -89,6 +88,7 @@
         <div id="history-overlay" class="hidden fixed inset-0 bg-black bg-opacity-50 backdrop-blur-sm z-10"></div>
 
         </div>
+        <div id="nav-overlay" class="hidden fixed inset-0 bg-black bg-opacity-50 backdrop-blur-sm z-10"></div>
 
         <div id="user-auth-area" class="fixed top-4 right-20 z-20 flex items-center gap-3">
             </div>
@@ -129,7 +129,7 @@
             </div>
         </aside>
 
-        <header class="text-center mb-6 pt-6">
+        <header class="text-center mb-4 pt-4">
               <h1 class="flex items-center justify-center text-4xl md:text-5xl font-bold text-blue-600 dark:text-blue-400"><img src="images/correctia-logo.png" alt="Correctia — Redacción con IA" class="w-56 md:w-64 h-auto"><span class="ml-2 text-4xl md:text-5xl">🚀</span></h1>
             <p id="header-subtitle" class="text-lg text-gray-600 dark:text-gray-400 mt-1">Tu navaja suiza de redacción con IA.</p>
         </header>
@@ -196,7 +196,6 @@
         </section>
        
 
-    </div>
 
     <footer class="w-full text-center p-4 text-gray-500 dark:text-gray-400 text-sm">
         <p>&copy; 2025 Correctia. Todos los derechos reservados.</p>

--- a/js/main.js
+++ b/js/main.js
@@ -262,6 +262,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const navMenu = document.getElementById("nav-menu");
     const menuToggleBtn = document.getElementById('menu-toggle');
     const menuItems = document.getElementById('menu-items');
+    const navOverlay = document.getElementById('nav-overlay');
     // --- AUTH, MODALS & SETTINGS LOGIC ---
     const showLoginModal = () => loginRequiredModal.classList.remove('hidden');
     const hideLoginModal = () => loginRequiredModal.classList.add('hidden');
@@ -532,11 +533,15 @@ document.addEventListener('DOMContentLoaded', () => {
             historyOverlay.classList.toggle('hidden');
             userAuthArea.classList.toggle('hidden');
             navMenu.classList.toggle("hidden");
+            navOverlay.classList.add('hidden');
+            menuItems.classList.add('hidden');
         });
         historyOverlay.addEventListener('click', () => {
             historyPanel.classList.add('hidden', 'translate-x-full');
             historyOverlay.classList.add('hidden');
             navMenu.classList.remove("hidden");
+            navOverlay.classList.add('hidden');
+            menuItems.classList.add('hidden');
             userAuthArea.classList.remove('hidden');
         });
 
@@ -596,6 +601,12 @@ document.addEventListener('DOMContentLoaded', () => {
 
         menuToggleBtn.addEventListener('click', () => {
             menuItems.classList.toggle('hidden');
+            navOverlay.classList.toggle('hidden');
+        });
+
+        navOverlay.addEventListener('click', () => {
+            menuItems.classList.add('hidden');
+            navOverlay.classList.add('hidden');
         });
 
         renderHistory();


### PR DESCRIPTION
## Summary
- remove redundant outer container and adjust top spacing
- add `nav-overlay` for blurred backdrop when menu is open
- show/hide overlay via JS and close when clicking outside
- tweak header margin to sit higher

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684b9f7b64308326936bd4428b8356b5