### PR TITLE
Move nav icon and add article advanced options

### DIFF
--- a/herramientas/articulos.html
+++ b/herramientas/articulos.html
@@ -29,7 +29,37 @@
                         <option value="formal">Formal</option>
                         <option value="informal">Informal</option>
                         <option value="casual">Casual</option>
+                        <option value="custom">Personalizado...</option>
                     </select>
+                    <input type="text" id="custom-tone" class="w-full p-2 mt-2 border border-gray-300 rounded-lg dark:bg-gray-700 hidden" placeholder="Escribe el tono deseado">
+                </div>
+
+                <button id="toggle-advanced" type="button" class="text-blue-600 hover:underline">Configuración avanzada</button>
+
+                <div id="advanced-section" class="hidden space-y-4 border-t pt-4">
+                    <div>
+                        <label for="audience-age" class="block mb-2 font-medium">Rango de edad del público objetivo</label>
+                        <input type="text" id="audience-age" class="w-full p-2 border border-gray-300 rounded-lg dark:bg-gray-700" placeholder="18-35, por ejemplo">
+                    </div>
+                    <div>
+                        <label for="markdown-format" class="block mb-2 font-medium">Formato Markdown</label>
+                        <select id="markdown-format" class="w-full p-2 border border-gray-300 rounded-lg dark:bg-gray-700">
+                            <option value="no" selected>No</option>
+                            <option value="si">Sí</option>
+                        </select>
+                    </div>
+                    <div>
+                        <label for="reading-level" class="block mb-2 font-medium">Nivel de lectura</label>
+                        <select id="reading-level" class="w-full p-2 border border-gray-300 rounded-lg dark:bg-gray-700">
+                            <option value="basico">Básico</option>
+                            <option value="intermedio">Intermedio</option>
+                            <option value="profesional">Profesional</option>
+                        </select>
+                    </div>
+                    <div>
+                        <label for="grammar-custom" class="block mb-2 font-medium">Personalización gramatical</label>
+                        <input type="text" id="grammar-custom" class="w-full p-2 border border-gray-300 rounded-lg dark:bg-gray-700" placeholder="Preferencias gramaticales">
+                    </div>
                 </div>
 
                 <div>
@@ -49,7 +79,15 @@
 
                 <button type="submit" class="bg-blue-600 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded-full">Generar Artículo</button>
             </form>
-            <div id="article-result" class="mt-6 whitespace-pre-wrap"></div>
+            <div id="article-result-section" class="mt-6 hidden">
+                <div class="flex justify-between items-center mb-3 border-b-2 border-gray-300 dark:border-gray-700 pb-2">
+                    <h2 class="text-2xl font-semibold">Artículo Generado</h2>
+                    <button id="copy-article" class="bg-gray-200 hover:bg-gray-300 dark:bg-gray-700 dark:hover:bg-gray-600 text-sm font-medium py-2 px-4 rounded-lg">Copiar</button>
+                </div>
+                <div class="bg-white dark:bg-gray-800 p-4 rounded-lg shadow">
+                    <pre id="article-result" class="whitespace-pre-wrap font-sans"></pre>
+                </div>
+            </div>
         </main>
     </div>
     <footer class="w-full text-center p-4 text-gray-500 dark:text-gray-400 text-sm">

--- a/index.html
+++ b/index.html
@@ -27,7 +27,7 @@
 <body class="bg-gray-100 dark:bg-gray-900 text-gray-800 dark:text-gray-200 font-sans flex flex-col min-h-screen">
 
         
-        <button id="settings-toggle" class="fixed top-4 left-4 z-20 bg-gray-700 hover:bg-gray-600 text-white font-bold p-3 rounded-full shadow-lg transition-transform transform hover:scale-110">
+        <button id="settings-toggle" class="fixed top-4 left-20 z-20 bg-gray-700 hover:bg-gray-600 text-white font-bold p-3 rounded-full shadow-lg transition-transform transform hover:scale-110">
             <img src="https://www.svgrepo.com/show/193270/settings-gear.svg" alt="Ajustes" class="h-5 w-5">
         </button>
         
@@ -91,7 +91,7 @@
         <div id="user-auth-area" class="fixed top-4 right-20 z-20 flex items-center gap-3">
             </div>
         
-        <div id="nav-menu" class="fixed top-4 right-4 z-20 relative">
+        <div id="nav-menu" class="fixed top-4 left-4 z-20 relative">
             <button id="menu-toggle" class="text-2xl bg-gray-700 hover:bg-gray-600 text-white p-2 rounded-lg">☰</button>
             <div id="menu-items" class="hidden absolute right-0 mt-2 w-48 bg-white dark:bg-gray-800 rounded-lg shadow-lg p-2 flex flex-col gap-2">
                 <button id="history-toggle" class="bg-gray-700 hover:bg-gray-600 text-white font-bold py-2 px-4 rounded-lg">🕒 Historial</button>

--- a/js/articulos.js
+++ b/js/articulos.js
@@ -2,21 +2,65 @@ document.addEventListener('DOMContentLoaded', () => {
     const form = document.getElementById('article-form');
     const topicInput = document.getElementById('article-topic');
     const toneSelect = document.getElementById('article-tone');
+    const customToneInput = document.getElementById('custom-tone');
     const sizeSelect = document.getElementById('article-size');
     const keywordsInput = document.getElementById('article-keywords');
+    const toggleAdvancedBtn = document.getElementById('toggle-advanced');
+    const advancedSection = document.getElementById('advanced-section');
+    const audienceAgeInput = document.getElementById('audience-age');
+    const markdownSelect = document.getElementById('markdown-format');
+    const readingLevelSelect = document.getElementById('reading-level');
+    const grammarCustomInput = document.getElementById('grammar-custom');
+    const resultSection = document.getElementById('article-result-section');
     const result = document.getElementById('article-result');
+    const copyArticleBtn = document.getElementById('copy-article');
+
+    toneSelect.addEventListener('change', () => {
+        if (toneSelect.value === 'custom') {
+            customToneInput.classList.remove('hidden');
+        } else {
+            customToneInput.classList.add('hidden');
+            customToneInput.value = '';
+        }
+    });
+
+    toggleAdvancedBtn.addEventListener('click', () => {
+        advancedSection.classList.toggle('hidden');
+    });
 
     form.addEventListener('submit', async (e) => {
         e.preventDefault();
         const topic = topicInput.value.trim();
         if (!topic) return;
+
         const tone = toneSelect.value;
+        const customTone = customToneInput.value.trim();
         const size = sizeSelect.value;
         const keywords = keywordsInput.value.trim();
+        const audienceAge = audienceAgeInput.value.trim();
+        const markdown = markdownSelect.value;
+        const readingLevel = readingLevelSelect.value;
+        const grammarCustom = grammarCustomInput.value.trim();
+
         let prompt = `Redacta un articulo detallado sobre: ${topic}`;
-        if (tone) prompt += `. Tono: ${tone}`;
+
+        if (tone === 'custom' && customTone) {
+            prompt += `. Tono: ${customTone}`;
+        } else if (tone) {
+            prompt += `. Tono: ${tone}`;
+        }
         if (size) prompt += `. Tama\u00f1o: ${size}`;
         if (keywords) prompt += `. Incluye las palabras clave: ${keywords}`;
+        if (audienceAge) prompt += `. Público objetivo de edad ${audienceAge}`;
+        if (readingLevel) prompt += `. Nivel de lectura: ${readingLevel}`;
+        if (grammarCustom) prompt += `. Ajustes gramaticales: ${grammarCustom}`;
+        if (markdown === 'si') {
+            prompt += `. Formatea el resultado en Markdown`;
+        } else {
+            prompt += `. No uses formato Markdown en el resultado`;
+        }
+
+        resultSection.classList.remove('hidden');
         result.textContent = 'Generando...';
         try {
             const res = await puter.ai.chat(prompt, { model: 'gpt-4.1-nano' });
@@ -25,5 +69,12 @@ document.addEventListener('DOMContentLoaded', () => {
             console.error('Error generando articulo:', err);
             result.textContent = 'Hubo un error al generar el articulo.';
         }
+    });
+
+    copyArticleBtn.addEventListener('click', () => {
+        navigator.clipboard.writeText(result.innerText).then(() => {
+            copyArticleBtn.innerText = '¡Copiado!';
+            setTimeout(() => { copyArticleBtn.innerText = 'Copiar'; }, 2000);
+        });
     });
 });


### PR DESCRIPTION
## Summary
- reposition nav menu to the left and offset settings button
- expand article generator with custom tone and advanced options
- render generated article in styled section with copy button
- update article JS to use new options and copy result

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684bc6a24e4c832696bfd9884c1e66e5