### PR TITLE
Implementa configuración de idioma y persona gramatical

### DIFF
--- a/herramientas/articulos.html
+++ b/herramientas/articulos.html
@@ -34,6 +34,30 @@
                     <input type="text" id="custom-tone" class="w-full p-2 mt-2 border border-gray-300 rounded-lg dark:bg-gray-700 hidden" placeholder="Escribe el tono deseado">
                 </div>
 
+
+                <div>
+                    <label for="article-size" class="block mb-2 font-medium">Tamaño (opcional)</label>
+                    <select id="article-size" class="w-full p-2 border border-gray-300 rounded-lg dark:bg-gray-700">
+                        <option value="" selected>Sin preferencia</option>
+                        <option value="pequeño">Pequeño</option>
+                        <option value="mediano">Mediano</option>
+                        <option value="grande">Grande</option>
+                    </select>
+                </div>
+
+                <div>
+                    <label for="article-keywords" class="block mb-2 font-medium">Palabras clave (opcional)</label>
+                    <input type="text" id="article-keywords" class="w-full p-2 border border-gray-300 rounded-lg dark:bg-gray-700" placeholder="SEO, marketing, IA...">
+                </div>
+
+                <div>
+                    <label for="article-language" class="block mb-2 font-medium">Idioma</label>
+                    <select id="article-language" class="w-full p-2 border border-gray-300 rounded-lg dark:bg-gray-700" required>
+                        <option value="español">Español</option>
+                        <option value="inglés">Inglés</option>
+                    </select>
+                </div>
+
                 <button id="toggle-advanced" type="button" class="text-blue-600 hover:underline">Configuración avanzada</button>
 
                 <div id="advanced-section" class="hidden space-y-4 border-t pt-4">
@@ -57,24 +81,13 @@
                         </select>
                     </div>
                     <div>
-                        <label for="grammar-custom" class="block mb-2 font-medium">Personalización gramatical</label>
-                        <input type="text" id="grammar-custom" class="w-full p-2 border border-gray-300 rounded-lg dark:bg-gray-700" placeholder="Preferencias gramaticales">
+                        <label for="person-grammar" class="block mb-2 font-medium">Persona gramatical</label>
+                        <select id="person-grammar" class="w-full p-2 border border-gray-300 rounded-lg dark:bg-gray-700">
+                            <option value="1ra persona">1ra persona</option>
+                            <option value="2da persona">2da persona</option>
+                            <option value="3ra persona">3ra persona</option>
+                        </select>
                     </div>
-                </div>
-
-                <div>
-                    <label for="article-size" class="block mb-2 font-medium">Tamaño (opcional)</label>
-                    <select id="article-size" class="w-full p-2 border border-gray-300 rounded-lg dark:bg-gray-700">
-                        <option value="" selected>Sin preferencia</option>
-                        <option value="pequeño">Pequeño</option>
-                        <option value="mediano">Mediano</option>
-                        <option value="grande">Grande</option>
-                    </select>
-                </div>
-
-                <div>
-                    <label for="article-keywords" class="block mb-2 font-medium">Palabras clave (opcional)</label>
-                    <input type="text" id="article-keywords" class="w-full p-2 border border-gray-300 rounded-lg dark:bg-gray-700" placeholder="SEO, marketing, IA...">
                 </div>
 
                 <button type="submit" class="bg-blue-600 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded-full">Generar Artículo</button>

--- a/js/articulos.js
+++ b/js/articulos.js
@@ -5,12 +5,13 @@ document.addEventListener('DOMContentLoaded', () => {
     const customToneInput = document.getElementById('custom-tone');
     const sizeSelect = document.getElementById('article-size');
     const keywordsInput = document.getElementById('article-keywords');
+    const languageSelect = document.getElementById('article-language');
     const toggleAdvancedBtn = document.getElementById('toggle-advanced');
     const advancedSection = document.getElementById('advanced-section');
     const audienceAgeInput = document.getElementById('audience-age');
     const markdownSelect = document.getElementById('markdown-format');
     const readingLevelSelect = document.getElementById('reading-level');
-    const grammarCustomInput = document.getElementById('grammar-custom');
+    const personGrammarSelect = document.getElementById('person-grammar');
     const resultSection = document.getElementById('article-result-section');
     const result = document.getElementById('article-result');
     const copyArticleBtn = document.getElementById('copy-article');
@@ -37,12 +38,13 @@ document.addEventListener('DOMContentLoaded', () => {
         const customTone = customToneInput.value.trim();
         const size = sizeSelect.value;
         const keywords = keywordsInput.value.trim();
+        const language = languageSelect.value;
         const audienceAge = audienceAgeInput.value.trim();
         const markdown = markdownSelect.value;
         const readingLevel = readingLevelSelect.value;
-        const grammarCustom = grammarCustomInput.value.trim();
+        const personGrammar = personGrammarSelect.value;
 
-        let prompt = `Redacta un articulo detallado sobre: ${topic}`;
+        let prompt = `Redacta un articulo detallado en ${language} sobre: ${topic}`;
 
         if (tone === 'custom' && customTone) {
             prompt += `. Tono: ${customTone}`;
@@ -53,12 +55,13 @@ document.addEventListener('DOMContentLoaded', () => {
         if (keywords) prompt += `. Incluye las palabras clave: ${keywords}`;
         if (audienceAge) prompt += `. Público objetivo de edad ${audienceAge}`;
         if (readingLevel) prompt += `. Nivel de lectura: ${readingLevel}`;
-        if (grammarCustom) prompt += `. Ajustes gramaticales: ${grammarCustom}`;
+        if (personGrammar) prompt += `. Persona gramatical: ${personGrammar}`;
         if (markdown === 'si') {
             prompt += `. Formatea el resultado en Markdown`;
         } else {
             prompt += `. No uses formato Markdown en el resultado`;
         }
+        prompt += `. Devuelve únicamente el artículo sin explicaciones.`;
 
         resultSection.classList.remove('hidden');
         result.textContent = 'Generando...';


### PR DESCRIPTION
## Summary
- añade campo de Idioma en la generación de artículos
- mueve la sección de configuración avanzada tras las opciones básicas
- reemplaza la personalización gramatical por la selección de persona gramatical
- actualiza el código JS para usar los nuevos campos e instruir a la IA a responder sin explicaciones

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684bc9e608688326a628c85f48d9a660