### PR TITLE
Move nav icon to top-right; remove username display

### DIFF
--- a/index.html
+++ b/index.html
@@ -91,7 +91,7 @@
         <div id="user-auth-area" class="fixed top-4 right-20 z-20 flex items-center gap-3">
             </div>
         
-        <div id="nav-menu" class="fixed top-4 left-4 z-20 relative">
+        <div id="nav-menu" class="fixed top-4 right-4 z-20 relative">
             <button id="menu-toggle" class="text-2xl bg-gray-700 hover:bg-gray-600 text-white p-2 rounded-lg">☰</button>
             <div id="menu-items" class="hidden absolute right-0 mt-2 w-48 bg-white dark:bg-gray-800 rounded-lg shadow-lg p-2 flex flex-col gap-2">
                 <button id="history-toggle" class="bg-gray-700 hover:bg-gray-600 text-white font-bold py-2 px-4 rounded-lg">🕒 Historial</button>

--- a/js/main.js
+++ b/js/main.js
@@ -264,8 +264,8 @@ document.addEventListener('DOMContentLoaded', () => {
 
     const updateAuthStateUI = async () => {
         if (puter.auth.isSignedIn()) {
-            const user = await puter.auth.getUser();
-            userAuthArea.innerHTML = `<span class="text-sm font-medium text-gray-800 dark:text-gray-200">${user.username}</span>`;
+            // Username display removed per design update
+            userAuthArea.innerHTML = '';
             logoutBtnSettings.classList.remove('hidden');
         } else {
             userAuthArea.innerHTML = `<button id="sign-in-btn" class="bg-green-600 text-white text-sm font-bold py-2 px-4 rounded-lg hover:bg-green-700">${getT('signIn')}</button>`;


### PR DESCRIPTION
## Summary
- position nav menu in the top-right corner
- stop displaying the signed-in username

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684d073884e88326ad9b9c7d567aa1c7