### PR TITLE
Improve menu icons and add article hint

### DIFF
--- a/index.html
+++ b/index.html
@@ -27,7 +27,7 @@
 <body class="bg-gray-100 dark:bg-gray-900 text-gray-800 dark:text-gray-200 font-sans flex flex-col min-h-screen">
 
         
-        <button id="settings-toggle" class="fixed top-4 left-20 z-20 bg-gray-700 hover:bg-gray-600 text-white font-bold p-3 rounded-full shadow-lg transition-transform transform hover:scale-110">
+        <button id="settings-toggle" class="fixed top-4 left-4 z-20 bg-gray-700 hover:bg-gray-600 text-white font-bold p-3 rounded-full shadow-lg transition-transform transform hover:scale-110">
             <img src="https://www.svgrepo.com/show/193270/settings-gear.svg" alt="Ajustes" class="h-5 w-5">
         </button>
         
@@ -88,15 +88,16 @@
         <div id="history-overlay" class="hidden fixed inset-0 bg-black bg-opacity-50 backdrop-blur-sm z-10"></div>
         <div id="nav-overlay" class="hidden fixed inset-0 bg-black bg-opacity-50 backdrop-blur-sm z-10"></div>
 
-        <div id="user-auth-area" class="fixed top-4 right-20 z-20 flex items-center gap-3">
+        <div id="user-auth-area" class="fixed top-4 right-16 z-20 flex items-center gap-3">
             </div>
         
         <div id="nav-menu" class="fixed top-4 right-4 z-20 relative">
-            <button id="menu-toggle" class="text-2xl bg-gray-700 hover:bg-gray-600 text-white p-2 rounded-lg">☰</button>
+            <button id="menu-toggle" class="bg-gray-700 hover:bg-gray-600 text-white p-2 rounded-lg"><img src="https://www.svgrepo.com/show/533000/menu.svg" alt="Menú" class="h-5 w-5"></button>
             <div id="menu-items" class="hidden absolute right-0 mt-2 w-48 bg-white dark:bg-gray-800 rounded-lg shadow-lg p-2 flex flex-col gap-2">
                 <button id="history-toggle" class="bg-gray-700 hover:bg-gray-600 text-white font-bold py-2 px-4 rounded-lg">🕒 Historial</button>
                 <a href="herramientas/articulos.html" id="create-articles" class="bg-green-600 hover:bg-green-700 text-white font-bold py-2 px-4 rounded-lg ml-2">Crear Artículos</a>
             </div>
+        <div id="articles-announcement" class="hidden fixed top-14 right-14 z-30 bg-blue-600 text-white text-sm px-3 py-2 rounded-lg shadow-lg">👈 Nuevo: crea artículos desde el menú</div>
         </div>
         
         <div id="settings-modal" class="hidden fixed inset-0 bg-black bg-opacity-50 backdrop-blur-sm z-30 flex items-center justify-center">

--- a/js/main.js
+++ b/js/main.js
@@ -258,6 +258,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const menuToggleBtn = document.getElementById('menu-toggle');
     const menuItems = document.getElementById('menu-items');
     const navOverlay = document.getElementById('nav-overlay');
+    const articlesAnnouncement = document.getElementById("articles-announcement");
     // --- AUTH, MODALS & SETTINGS LOGIC ---
     const showLoginModal = () => loginRequiredModal.classList.remove('hidden');
     const hideLoginModal = () => loginRequiredModal.classList.add('hidden');
@@ -589,12 +590,23 @@ document.addEventListener('DOMContentLoaded', () => {
         menuToggleBtn.addEventListener('click', () => {
             menuItems.classList.toggle('hidden');
             navOverlay.classList.toggle('hidden');
+            if (!localStorage.getItem("articlesHintShown")) {
+                localStorage.setItem("articlesHintShown", "true");
+                articlesAnnouncement.classList.add("hidden");
+            }
         });
 
         navOverlay.addEventListener('click', () => {
             menuItems.classList.add('hidden');
             navOverlay.classList.add('hidden');
         });
+        if (!localStorage.getItem("articlesHintShown")) {
+            articlesAnnouncement.classList.remove("hidden");
+            setTimeout(() => {
+                articlesAnnouncement.classList.add("hidden");
+                localStorage.setItem("articlesHintShown", "true");
+            }, 6000);
+        }
 
         renderHistory();
     }


### PR DESCRIPTION
## Summary
- update navigation and settings icons placement
- use SVG icon for menu button
- show a one-time hint for creating articles

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684d2bb4c5e48326a5e61cfd15d713af