### PR TITLE
Fix mobile nav menu dismissal

### DIFF
--- a/index.html
+++ b/index.html
@@ -92,7 +92,7 @@
         <div id="nav-menu" class="fixed top-4 right-4 z-20 relative" style="top:calc(1rem - 5px);right:calc(1rem - 26px)">
           <button id="menu-toggle" class="text-2xl bg-gray-700 hover:bg-gray-600 text-white p-2 rounded-lg shadow-lg transition-transform transform hover:scale-110">☰</button>
             <div id="menu-items" class="hidden fixed inset-0 z-30 flex items-center justify-center">
-                <div class="bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg shadow-xl p-4 w-64">
+                <div id="menu-content" class="bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg shadow-xl p-4 w-64">
                     <ul class="flex flex-col gap-2">
                         <li><button id="history-toggle" class="w-full bg-gray-700 hover:bg-gray-600 text-white font-bold py-2 px-4 rounded-lg">🕒 Historial</button></li>
                         <li><button id="settings-toggle" class="w-full bg-blue-600 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded-lg">⚙ Ajustes</button></li>

--- a/js/main.js
+++ b/js/main.js
@@ -336,6 +336,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const navMenu = document.getElementById("nav-menu");
     const menuToggleBtn = document.getElementById('menu-toggle');
     const menuItems = document.getElementById('menu-items');
+    const menuContent = document.getElementById('menu-content');
     const navOverlay = document.getElementById('nav-overlay');
     // --- AUTH, MODALS & SETTINGS LOGIC ---
     const showLoginModal = () => loginRequiredModal.classList.remove('hidden');
@@ -683,7 +684,7 @@ document.addEventListener('DOMContentLoaded', () => {
         });
 
         menuItems.addEventListener('click', (e) => {
-            if (e.target === menuItems) {
+            if (!menuContent.contains(e.target)) {
                 menuItems.classList.add('hidden');
                 navOverlay.classList.add('hidden');
                 menuToggleBtn.classList.remove('hidden');


### PR DESCRIPTION
## Summary
- identify the menu content container so clicking outside will close it
- close menu when clicking anywhere outside the menu content

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684e86c38e308326b0bfe26a95296102